### PR TITLE
fix: connect nebula-sync to uptimekuma via shared docker network

### DIFF
--- a/playbooks/proxmox_primary/services.yml
+++ b/playbooks/proxmox_primary/services.yml
@@ -85,10 +85,8 @@
     - scheduled_reboot
     - firewall
     - pihole_health
-    - nebula_sync
     - pihole_docker
-    - role: syncthing
-      tags: syncthing
+    - syncthing
     - couchdb
     - docker_auto_update
     - promtail
@@ -98,3 +96,4 @@
     - uptimekuma
     - loki
     - grafana
+    - nebula_sync

--- a/roles/nebula_sync/defaults/main.yml
+++ b/roles/nebula_sync/defaults/main.yml
@@ -1,3 +1,3 @@
 nebula_sync_main_ip: "{{ vms.services.ip }}"
 nebula_sync_backup_ip: "{{ vms['pihole-secondary'].ip }}"
-nebula_sync_uptimekuma_push_url: "http://10.0.0.44:3001/api/push/fLPIxjbqTDryHGSCPoSxngDwFH0iib38?status=up&msg=OK&ping="
+nebula_sync_uptimekuma_push_url: "http://uptime-kuma:3001/api/push/fLPIxjbqTDryHGSCPoSxngDwFH0iib38?status=up&msg=OK&ping="

--- a/roles/nebula_sync/templates/docker-compose.yml.j2
+++ b/roles/nebula_sync/templates/docker-compose.yml.j2
@@ -5,6 +5,8 @@ services:
     image: ghcr.io/lovelaze/nebula-sync:latest
     container_name: nebula-sync
     restart: unless-stopped
+    networks:
+      - monitoring
     environment:
       - PRIMARY=http://{{ nebula_sync_main_ip}}|{{ pihole_password }}
       - REPLICAS=http://{{ nebula_sync_backup_ip }}|{{ pihole_password }}
@@ -13,3 +15,7 @@ services:
       - CRON=15 * * * *
       - WEBHOOK_SYNC_SUCCESS_URL={{ nebula_sync_uptimekuma_push_url }}
       - WEBHOOK_SYNC_SUCCESS_METHOD=GET
+
+networks:
+  monitoring:
+    external: true

--- a/roles/uptimekuma/templates/docker-compose.yml.j2
+++ b/roles/uptimekuma/templates/docker-compose.yml.j2
@@ -7,9 +7,16 @@ services:
       - "3001:3001"
     volumes:
       - ./data:/app/data
+    networks:
+      - monitoring
     healthcheck:
       test: ["CMD", "wget", "--spider", "-q", "http://localhost:3001/api/status"]
       interval: 30s
       timeout: 10s
       retries: 3
       start_period: 40s
+
+networks:
+  monitoring:
+    name: monitoring
+    driver: bridge


### PR DESCRIPTION
- Add 'monitoring' bridge network to uptimekuma compose
- Join nebula-sync to external 'monitoring' network
- Update push URL to use container name (uptime-kuma:3001) instead of host IP
- Run nebula_sync after uptimekuma in services playbook