### PR TITLE
fix(docker_auto_update): always run compose up -d even if pull fails

### DIFF
--- a/roles/docker_auto_update/templates/docker_auto_update.sh.j2
+++ b/roles/docker_auto_update/templates/docker_auto_update.sh.j2
@@ -47,26 +47,32 @@ for compose_path in "${docker_auto_update_compose_paths[@]}"; do
     }
 
     logger -t "$SCRIPT_NAME" -p user.info "Running docker compose pull for $app_name"
-    if docker compose pull 2>&1 | logger -t "$SCRIPT_NAME" -p user.info; then
+    pull_failed=0
+    if ! docker compose pull 2>&1 | logger -t "$SCRIPT_NAME" -p user.info; then
+        logger -t "$SCRIPT_NAME" -p user.err "docker compose pull failed for $app_name, will still ensure container is running"
+        pull_failed=1
+    else
         logger -t "$SCRIPT_NAME" -p user.info "Pull successful for $app_name"
+    fi
 
-        logger -t "$SCRIPT_NAME" -p user.info "Running docker compose up -d for $app_name"
-        if docker compose up -d 2>&1 | logger -t "$SCRIPT_NAME" -p user.info; then
+    logger -t "$SCRIPT_NAME" -p user.info "Running docker compose up -d for $app_name"
+    if docker compose up -d 2>&1 | logger -t "$SCRIPT_NAME" -p user.info; then
+        if [ "$pull_failed" -eq 0 ]; then
             logger -t "$SCRIPT_NAME" -p user.info "Update successful for $app_name"
             SUCCESS_COUNT=$((SUCCESS_COUNT + 1))
             UPDATED_APPS="${UPDATED_APPS}
 - $app_name"
         else
-            logger -t "$SCRIPT_NAME" -p user.err "docker compose up -d failed for $app_name"
+            logger -t "$SCRIPT_NAME" -p user.warning "Pull failed but container is running for $app_name"
             FAILURE_COUNT=$((FAILURE_COUNT + 1))
             FAILED_APPS="${FAILED_APPS}
-- $app_name (compose up failed)"
+- $app_name (pull failed, running on existing image)"
         fi
     else
-        logger -t "$SCRIPT_NAME" -p user.err "docker compose pull failed for $app_name"
+        logger -t "$SCRIPT_NAME" -p user.err "docker compose up -d failed for $app_name"
         FAILURE_COUNT=$((FAILURE_COUNT + 1))
         FAILED_APPS="${FAILED_APPS}
-- $app_name (pull failed)"
+- $app_name (compose up failed)"
     fi
 done
 


### PR DESCRIPTION
## Problem

When \`docker compose pull\` fails (network error, rate limit, etc.), the script previously skipped \`docker compose up -d\` entirely. Docker's \`unless-stopped\` restart policy does **not** recover from an explicit stop, so the container would remain down indefinitely.

This caused Loki to be stopped for 20+ hours after a failed update attempt, breaking the entire log pipeline (Promtail → Loki → Grafana).

## Fix

Always run \`docker compose up -d\` regardless of whether the pull succeeded. This ensures:
- ✅ Successful pull → container updated and running
- ✅ Failed pull → container stays running on its existing image
- ✅ Failed \`compose up\` → still counted as failure and logged

The pull failure is still logged as an error and counted in \`FAILURE_COUNT\`.